### PR TITLE
Include active projects in preferences table

### DIFF
--- a/scripts/save.py
+++ b/scripts/save.py
@@ -27,7 +27,8 @@ import time
 import os.path
 import sys
 import string
-import subprocess
+import subprocesse
+from datetime import datetime
 
 import pandas as pd
 
@@ -141,8 +142,8 @@ def harvest_vs_forecast(vis):
         try:
             plot = vis.plot_forecast_harvest(
                 project_id,
-                start_date=pd.datetime.now() - pd.Timedelta("365 days"),
-                end_date=pd.datetime.now(),
+                start_date=datetime.now() - pd.Timedelta("365 days"),
+                end_date=datetime.now(),
             )
 
             save_fig(plot, HARVEST_DIR, save_name)

--- a/scripts/whiteboard.py
+++ b/scripts/whiteboard.py
@@ -1,6 +1,7 @@
 import time
 import os.path
 import sys
+from datetime import datetime
 
 import pandas as pd
 
@@ -43,7 +44,7 @@ if __name__ == "__main__":
     if len(sys.argv) > 1:
         start_date = pd.to_datetime(sys.argv[1])
     else:
-        start_date = pd.datetime.now() - pd.Timedelta("30 days")
+        start_date = datetime.now() - pd.Timedelta("30 days")
 
     if len(sys.argv) > 2:
         end_date = pd.to_datetime(sys.argv[2])

--- a/wimbledon/github/preferences_availability.py
+++ b/wimbledon/github/preferences_availability.py
@@ -233,25 +233,25 @@ def get_preferences(
     resreqdf = wim.project_resourcereq
     unconfdf = wim.project_unconfirmed
     allocdf = wim.project_allocated
-    req_df = resreqdf + unconfdf + allocdf
+    totdf = resreqdf + unconfdf + allocdf
 
     if first_date:
         resreqdf = resreqdf[resreqdf.index >= first_date]
         unconfdf = unconfdf[unconfdf.index >= first_date]
         allocdf = allocdf[allocdf.index >= first_date]
-        reqdf = reqdf[reqdf.index >= first_date]
+        totdf = totdf[totdf.index >= first_date]
 
     if last_date:
         resreqdf = resreqdf[resreqdf.index <= last_date]
         unconfdf = unconfdf[unconfdf.index <= last_date]
         allocdf = allocdf[allocdf.index <= last_date]
-        reqdf = reqdf[reqdf.index <= last_date]
+        totdf = totdf[totdf.index <= last_date]
 
     # grouped by month and mean taken
-    resreqdf = resreqdf.resample("MS").mean()
-    unconfdf = unconfdf.resample("MS").mean()
-    allocdf = allocdf.resample("MS").mean()
-    reqdf = reqdf.resample("MS").mean()
+    #resreqdf = resreqdf.resample("MS").mean()
+    #unconfdf = unconfdf.resample("MS").mean()
+    #allocdf = allocdf.resample("MS").mean()
+    #totdf = totdf.resample("MS").mean()
 
     if person:
         names = [person]
@@ -282,8 +282,8 @@ def get_preferences(
             ) and not math.isnan(issue_num):
                 project_name = wim.projects.loc[project_id, "name"]
 
-                dates_req = req_df.index[
-                    req_df[project_id] > 0
+                dates_req = totdf.index[
+                    totdf[project_id] > 0
                 ]
                 req_start_date = dates_req[0]
                 req_end_date = dates_req[-1]
@@ -343,7 +343,6 @@ def get_preferences(
                     ].mean()
 
                     if resreq >= 0.01:
-                        project_title += str(round(resreq, 1)) + " R"
                         if len(dates_alloc) > 0:
                             pre = " + "
                             post = " R"

--- a/wimbledon/github/preferences_availability.py
+++ b/wimbledon/github/preferences_availability.py
@@ -202,9 +202,7 @@ def get_preference_data(wim, github_token, emoji_mapping=None):
             if emoji_name:
                 emoji = emoji_mapping[emoji_name]
             else:
-                emoji = (
-                    "❓"
-                )  # For team members who have not given a preference to the project
+                emoji = "❓"  # For team members who have not given a preference to the project
             emojis.append(emoji)
         preference_data[wim.get_project_name(project_id)] = emojis
     preference_data_df = pd.DataFrame(preference_data).set_index("Person")
@@ -218,7 +216,7 @@ def get_preference_data(wim, github_token, emoji_mapping=None):
 def get_preferences(
     wim,
     preference_data_df,
-    first_date=False,
+    first_date=datetime.now(),
     last_date=False,
     person=False,
     project=False,
@@ -230,19 +228,31 @@ def get_preferences(
     Table values show the preference emojis alongside the mean availability the person has for the resource required period and
     the mean resource required for the range between the first month with resource required and the last.
     """
-    # Get the data on project resource requirement from Forecast
-    # grouped by month and mean taken
-    resreqdf = wim.project_resourcereq.resample("MS").mean()
-    #  Also consider unconfirmed projects
-    unconfdf = wim.project_unconfirmed.resample("MS").mean()
+
+    # Get the data on project resource required, unconfirmed and allocated from Forecast
+    resreqdf = wim.project_resourcereq
+    unconfdf = wim.project_unconfirmed
+    allocdf = wim.project_allocated
+    req_df = resreqdf + unconfdf + allocdf
 
     if first_date:
         resreqdf = resreqdf[resreqdf.index >= first_date]
         unconfdf = unconfdf[unconfdf.index >= first_date]
+        allocdf = allocdf[allocdf.index >= first_date]
+        reqdf = reqdf[reqdf.index >= first_date]
+
     if last_date:
         resreqdf = resreqdf[resreqdf.index <= last_date]
         unconfdf = unconfdf[unconfdf.index <= last_date]
-      
+        allocdf = allocdf[allocdf.index <= last_date]
+        reqdf = reqdf[reqdf.index <= last_date]
+
+    # grouped by month and mean taken
+    resreqdf = resreqdf.resample("MS").mean()
+    unconfdf = unconfdf.resample("MS").mean()
+    allocdf = allocdf.resample("MS").mean()
+    reqdf = reqdf.resample("MS").mean()
+
     if person:
         names = [person]
     else:
@@ -261,37 +271,60 @@ def get_preferences(
     for project_id in resreqdf:
         if not project or project == project_id:
             # If a project name or project id is provided, only get data for that project
-            # Get the dates for each month that the project has a resource requirement > 0           
+            # Get the dates for each month that the project has a resource requirement > 0
             dates_resreq = resreqdf.index[resreqdf[project_id] > 0]
             dates_unconf = unconfdf.index[unconfdf[project_id] > 0]
+            dates_alloc = allocdf.index[allocdf[project_id] > 0]
+
             issue_num = wim.projects.loc[project_id]["github"]
-            if (len(dates_resreq) > 0 or len(dates_unconf) > 0) and not math.isnan(
-                issue_num
-            ):
+            if (
+                len(dates_resreq) > 0 or len(dates_unconf) > 0 or len(dates_alloc) > 0
+            ) and not math.isnan(issue_num):
                 project_name = wim.projects.loc[project_id, "name"]
 
-                req_or_unconf_df = resreqdf + unconfdf
-                dates_req_or_unconf = req_or_unconf_df.index[
-                    req_or_unconf_df[project_id] > 0
+                dates_req = req_df.index[
+                    req_df[project_id] > 0
                 ]
-                unconf_or_req_start_date = dates_req_or_unconf[0]
-                unconf_or_req_end_date = dates_req_or_unconf[-1]
+                req_start_date = dates_req[0]
+                req_end_date = dates_req[-1]
 
-                if first_date and unconf_or_req_start_date < first_date:
-                    unconf_or_req_start_date = first_date
-                if last_date and unconf_or_req_end_date > last_date:
-                    unconf_or_req_end_date = last_date
+                if first_date and req_start_date < first_date:
+                    req_start_date = first_date
+                if last_date and req_end_date > last_date:
+                    req_end_date = last_date
 
                 project_title = (
                     project_name
                     + "<br>#"
                     + str(int(issue_num))
                     + "<br>"
-                    + unconf_or_req_start_date.strftime("%Y-%m")
+                    + req_start_date.strftime("%Y-%m")
                     + " to "
-                    + unconf_or_req_end_date.strftime("%Y-%m")
+                    + req_end_date.strftime("%Y-%m")
                     + "<br>"
+                    + "FTE: "
                 )
+
+                if len(dates_alloc) > 0:
+                    # if at least one month in the dataframe has a resource requirement of more than 0 FTE
+                    first_alloc_date = dates_alloc[0]
+                    last_alloc_date = dates_alloc[-1]
+                    if first_date and first_alloc_date < first_date:
+                        first_alloc_date = first_date
+                    if last_date and last_alloc_date > last_date:
+                        last_alloc_date = last_date
+
+                    # get mean project requirement in date range
+                    alloc = allocdf.loc[
+                        (allocdf.index >= first_alloc_date)
+                        & (allocdf.index <= last_alloc_date),
+                        project_id,
+                    ].mean()
+
+                    if alloc >= 0.01:
+                        project_title += str(round(alloc, 1)) + " A"
+                else:
+                    alloc = 0
 
                 if len(dates_resreq) > 0:
                     # if at least one month in the dataframe has a resource requirement of more than 0 FTE
@@ -301,7 +334,7 @@ def get_preferences(
                         first_resreq_date = first_date
                     if last_date and last_resreq_date > last_date:
                         last_resreq_date = last_date
-                    
+
                     # get mean project requirement in date range
                     resreq = resreqdf.loc[
                         (resreqdf.index >= first_resreq_date)
@@ -310,7 +343,14 @@ def get_preferences(
                     ].mean()
 
                     if resreq >= 0.01:
-                        project_title += str(round(resreq, 1)) + " FTE"
+                        project_title += str(round(resreq, 1)) + " R"
+                        if len(dates_alloc) > 0:
+                            pre = " + "
+                            post = " R"
+                        else:
+                            pre = ""
+                            post = " R"
+                        project_title += pre + "" + str(round(resreq, 1)) + post
                 else:
                     resreq = 0
 
@@ -322,7 +362,7 @@ def get_preferences(
                         first_unconf_date = first_date
                     if last_date and last_unconf_date > last_date:
                         last_unconf_date = last_date
-                    
+
                     # get mean project requirement in date range
                     unconf = unconfdf.loc[
                         (unconfdf.index >= first_unconf_date)
@@ -332,12 +372,12 @@ def get_preferences(
 
                     if unconf >= 0.01:
                         # add a separator between required and unconfirmed FTE if both present
-                        if len(dates_resreq) > 0:
+                        if len(dates_resreq) > 0 or len(dates_alloc) > 0:
                             pre = " + "
-                            post = " UNC"
+                            post = " U"
                         else:
                             pre = ""
-                            post = " UNC FTE"
+                            post = " U"
                         project_title += pre + "" + str(round(unconf, 1)) + post
                 else:
                     unconf = 0
@@ -352,14 +392,18 @@ def get_preferences(
                 emoji_data = []
                 for name in names:
                     person_availability = get_person_availability(
-                        wim, name, unconf_or_req_start_date, unconf_or_req_end_date
+                        wim, name, req_start_date, req_end_date
                     )
 
-                    percentage_availability = round(
-                        (person_availability / (unconf + resreq)) * 100
-                    )
+                    if (unconf + resreq) > 0:
+                        percentage_availability = round(
+                            (person_availability / (unconf + resreq)) * 100
+                        )
+                    else:
+                        percentage_availability = None
+
                     emoji = preference_data_df[project_name][name]
-                    if emojis_only:
+                    if emojis_only or percentage_availability is None:
                         emoji_data.append(emoji)
                     else:  # Include availability
                         emoji_data.append(
@@ -461,7 +505,7 @@ def get_preferences(
     return html_table
 
 
-def get_all_preferences_table(wim=None, first_date=None, last_date=None):
+def get_all_preferences_table(wim=None, first_date=datetime.now(), last_date=None):
     """
     Create the HTML table described in get_preferences() with default settings
     i.e. for all team members with at least one preference emoji and all projects

--- a/wimbledon/harvest/api_interface.py
+++ b/wimbledon/harvest/api_interface.py
@@ -7,7 +7,6 @@ import json
 import requests
 
 import pandas as pd
-from pandas.io.json import json_normalize
 
 import time
 
@@ -47,7 +46,7 @@ def get_forecast():
         """Takes an api response in the pyforecast foremat and converts it into a pandas data frame."""
         results = [json.loads(result.to_json()) for result in api_response]
 
-        df = json_normalize(results)
+        df = pd.json_normalize(results)
         df.set_index("id", inplace=True)
 
         return df
@@ -228,7 +227,7 @@ def get_harvest(with_tracked_time=True, with_assignments=False):
             response = requests.get(url, headers=headers)
             json_response = response.json()
 
-            df = json_normalize(json_response[table])
+            df = pd.json_normalize(json_response[table])
 
             diff = time.time() - req_time
             print("{:.1f} seconds".format(diff))
@@ -241,7 +240,7 @@ def get_harvest(with_tracked_time=True, with_assignments=False):
                 response = requests.get(url, headers=headers)
                 json_response = response.json()
 
-                new_entries = json_normalize(json_response[table])
+                new_entries = pd.json_normalize(json_response[table])
                 df = df.append(new_entries)
 
                 diff = time.time() - req_time

--- a/wimbledon/harvest/api_interface.py
+++ b/wimbledon/harvest/api_interface.py
@@ -208,7 +208,7 @@ def get_harvest(with_tracked_time=True, with_assignments=False):
     if with_tracked_time:
         """
         Issues with python-harvest module:
-        
+
         time_entries: Currently fails due to time_entries.cost_rate should be "float" instead of "NoneType" error
 
         client_contacts, invoices, estimates, expenses: Also fail, usually due to some missing field error, but not sure we

--- a/wimbledon/vis/HTMLWriter.py
+++ b/wimbledon/vis/HTMLWriter.py
@@ -4,14 +4,15 @@ and convert it into a styled HTML table.
 The primary function is make_whiteboard(df, key_type, display)"""
 
 from distinctipy import distinctipy
-
 import pandas as pd
+
 from wimbledon import Wimbledon
+
 import string
 import re
 import sys
 import os.path
-
+from datetime import datetime
 
 def get_name_id(name):
     """name is a string of cell contents which may include:
@@ -539,8 +540,8 @@ if __name__ == "__main__":
     print("GET WHITEBOARD DATAFRAME")
     df = wim.whiteboard(
         key_type,
-        pd.datetime.now() - pd.Timedelta("30 days"),
-        pd.datetime.now() + pd.Timedelta("365 days"),
+        datetime.now() - pd.Timedelta("30 days"),
+        datetime.now() + pd.Timedelta("365 days"),
         "MS",
     )
 

--- a/wimbledon/vis/Visualise.py
+++ b/wimbledon/vis/Visualise.py
@@ -3,14 +3,13 @@ import pandas as pd
 
 from copy import deepcopy
 import re
+from  datetime import datetime
 
 from wimbledon import Wimbledon
 from wimbledon import select_date_range
-
 from wimbledon.vis import HTMLWriter
 
 from distinctipy import colorsets
-
 colorsets.set_palette()
 import matplotlib.pyplot as plt
 import seaborn as sns
@@ -66,12 +65,12 @@ class Visualise:
 
         #  set default time parameters
         if start_date is None:
-            self.START_DATE = pd.datetime.now() - pd.Timedelta("30 days")
+            self.START_DATE = datetime.now() - pd.Timedelta("30 days")
         else:
             self.START_DATE = start_date
 
         if end_date is None:
-            self.END_DATE = pd.datetime.now() + pd.Timedelta("365 days")
+            self.END_DATE = datetime.now() + pd.Timedelta("365 days")
         else:
             self.END_DATE = end_date
 
@@ -385,11 +384,11 @@ class Visualise:
 
     def highlight_allocations(self, df):
         """Function to conditionally style a data frame:
-            Total allocations above 1.0 are highlighted red,
-            above 0.8 orange, 0.8 yellow, and below 0.8 green.
+        Total allocations above 1.0 are highlighted red,
+        above 0.8 orange, 0.8 yellow, and below 0.8 green.
 
-            Individual project allocations are coloured blue when
-            the person is active and grey when inactive on that project"""
+        Individual project allocations are coloured blue when
+        the person is active and grey when inactive on that project"""
 
         def highlight_tot(series):
             """function used to apply highlighting to the TOTAL column"""
@@ -647,10 +646,10 @@ class Visualise:
         )
 
         if today is None:
-            today = pd.datetime.now()
+            today = datetime.now()
 
         # move start date to 1st of specified month (fixes some display issues)
-        start_date = pd.datetime(start_date.year, start_date.month, 1)
+        start_date = datetime(start_date.year, start_date.month, 1)
 
         # ----------
         # DEMAND

--- a/wimbledon/wimbledon.py
+++ b/wimbledon/wimbledon.py
@@ -50,7 +50,7 @@ class Wimbledon:
         proj_hrs_per_day=None,
     ):
         """Load and group Wimbledon data.
-        
+
         Keyword Arguments:
             update_db {bool} -- update the database before loading data (default: {False})
             work_hrs_per_day {numeric} -- hours in normal working day (default: 8)
@@ -285,9 +285,9 @@ class Wimbledon:
     def whiteboard(self, key_type, start_date, end_date, freq):
         """Create the raw, unstyled, whiteboard visualisation.
 
-            Dataframe with the rows being key_type (project or person ids), the columns
-        dates and the cell values being either a person or project and their time allocation, sorted by time allocation.
-]       """
+                    Dataframe with the rows being key_type (project or person ids), the columns
+                dates and the cell values being either a person or project and their time allocation, sorted by time allocation.
+        ]"""
         # TODO move this function somewhere else?
         if key_type == "project":
             # copy to prevent overwriting original
@@ -743,14 +743,14 @@ class Wimbledon:
 
     def __client_from_project_tracking(self, tracking):
         """Group previously calculated project tracking values by client.
-        
+
         Arguments:
             tracking {pd.DataFrame or dict} -- a single dataframe or a dict of
             dataframes containing project ids as columns.
-        
+
         Raises:
             TypeError: if tracking is not an instance of pd.DataFrame or dict.
-        
+
         Returns:
             pd.DataFrame or dict -- same format as tracking except with columns
             now being client ids.


### PR DESCRIPTION
Include active projects in the preferences table, even if those projects don't have "resource required" or "unconfirmed" allocations.

Replace some deprecated pandas functions.