### PR TITLE
Fix/get assignments

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ pandas>=0.24
 sqlalchemy>=1.3.4
 psycopg2-binary>=2.8.2
 holidays==0.9.10
-Jinja2==2.10.1
+Jinja2==2.11.3
 openpyxl==2.6.1
 git+https://github.com/alan-turing-institute/pyforecast.git
 seaborn==0.9.0

--- a/wimbledon/harvest/api_interface.py
+++ b/wimbledon/harvest/api_interface.py
@@ -13,19 +13,24 @@ import time
 import sqlalchemy as sqla
 import subprocess
 import os
-
+from datetime import date, timedelta
 
 def check_dir(directory):
     if not os.path.exists(directory):
         os.makedirs(directory)
 
 
-def get_forecast():
+def get_forecast(
+    start_date=date(2016, 1, 1),
+    end_date=date.today() + timedelta(days=365 * 3)
+):
     """
     Extract forecast data from its API using the pyforecast package.
 
     NB: The forecast API is not public and is undocumented. See:
     https://help.getharvest.com/forecast/faqs/faq-list/api/
+    
+    start_date, end_date: date range to query assignments between.
     """
     start = time.time()
 
@@ -70,7 +75,9 @@ def get_forecast():
     milestones = response_to_df(api.get_milestones())
 
     print("ASSIGNMENTS")
-    assignments = response_to_df(api.get_assignments())
+    assignments = response_to_df(
+        api.get_assignments(start_date=start_date, end_date=end_date)
+    )
 
     print("=" * 50)
     print("DONE! ({:.1f}s)".format(time.time() - start))

--- a/wimbledon/wimbledon.py
+++ b/wimbledon/wimbledon.py
@@ -6,6 +6,7 @@ import os.path
 import subprocess
 import re
 import numpy as np
+import warnings
 
 import wimbledon.config
 import wimbledon.harvest.db_interface
@@ -207,10 +208,11 @@ class Wimbledon:
         person_id = self.people.loc[(self.people["name"] == name)]
 
         if len(person_id) != 1:
-            raise ValueError(
+            warnings.warn(
                 "Could not find unique person with name "
                 + name
-                + ". This person may have unlinked Harvest & Forecast accounts."
+                + ". This person may have unlinked Harvest & Forecast accounts. "
+                " Returning first available index. This may cause errors elsewhere!"
             )
 
         return person_id.index[0]
@@ -478,7 +480,6 @@ class Wimbledon:
             sheet.rename(proj_names_with_url, axis="index", level=1, inplace=True)
 
         elif key_type == "person":
-
             # Get person association group
             person_idx = [
                 self.get_person_id(name) for name in sheet.index.get_level_values(0)


### PR DESCRIPTION
- Add date ranges to Forecast assignment queries (as now required by API)
- Skip errors caused by duplicate names (can be caused by user archived on Forecast but not Harvest or vice-versa)
- Update GitHub user mappings